### PR TITLE
Add StateTree as a supported audit asset type

### DIFF
--- a/src/dotnet/ReSharperPlugin.Fathom/Formatting/AuditMarkdownFormatter.cs
+++ b/src/dotnet/ReSharperPlugin.Fathom/Formatting/AuditMarkdownFormatter.cs
@@ -30,6 +30,10 @@ public static class AuditMarkdownFormatter
             sb.Append("**Structures:** ").AppendLine(result.StructureCount.ToString());
         if (result.ControlRigCount > 0)
             sb.Append("**ControlRigs:** ").AppendLine(result.ControlRigCount.ToString());
+        if (result.BehaviorTreeCount > 0)
+            sb.Append("**BehaviorTrees:** ").AppendLine(result.BehaviorTreeCount.ToString());
+        if (result.StateTreeCount > 0)
+            sb.Append("**StateTrees:** ").AppendLine(result.StateTreeCount.ToString());
         if (result.ErrorCount > 0)
             sb.Append("**Errors:** ").AppendLine(result.ErrorCount.ToString());
         sb.AppendLine();
@@ -78,6 +82,26 @@ public static class AuditMarkdownFormatter
         {
             sb.AppendLine("## ControlRigs");
             foreach (var e in result.ControlRigs.OrderBy(b => b.Name))
+            {
+                FormatEntryLine(sb, e);
+            }
+            sb.AppendLine();
+        }
+
+        if (result.BehaviorTrees != null && result.BehaviorTrees.Count > 0)
+        {
+            sb.AppendLine("## BehaviorTrees");
+            foreach (var e in result.BehaviorTrees.OrderBy(b => b.Name))
+            {
+                FormatEntryLine(sb, e);
+            }
+            sb.AppendLine();
+        }
+
+        if (result.StateTrees != null && result.StateTrees.Count > 0)
+        {
+            sb.AppendLine("## StateTrees");
+            foreach (var e in result.StateTrees.OrderBy(b => b.Name))
             {
                 FormatEntryLine(sb, e);
             }

--- a/src/dotnet/ReSharperPlugin.Fathom/Handlers/IndexHandler.cs
+++ b/src/dotnet/ReSharperPlugin.Fathom/Handlers/IndexHandler.cs
@@ -115,6 +115,7 @@ public class IndexHandler : IRequestHandler
         var auditCr = 0;
         var auditMat = 0;
         var auditBt = 0;
+        var auditSt = 0;
         var auditStatus = "N/A";
         if (isUe)
         {
@@ -130,7 +131,8 @@ public class IndexHandler : IRequestHandler
                 auditCr = auditData.ControlRigCount;
                 auditMat = auditData.MaterialCount;
                 auditBt = auditData.BehaviorTreeCount;
-                auditBp = auditTotal - auditDt - auditDa - auditStruct - auditCr - auditMat - auditBt;
+                auditSt = auditData.StateTreeCount;
+                auditBp = auditTotal - auditDt - auditDa - auditStruct - auditCr - auditMat - auditBt - auditSt;
                 auditStatus = auditTotal > 0
                     ? (auditStale > 0 ? "Stale" : "Fresh")
                     : "Not Ready";
@@ -173,6 +175,7 @@ public class IndexHandler : IRequestHandler
             .Replace("{{AUDIT_CR}}", auditCr.ToString())
             .Replace("{{AUDIT_MAT}}", auditMat.ToString())
             .Replace("{{AUDIT_BT}}", auditBt.ToString())
+            .Replace("{{AUDIT_ST}}", auditSt.ToString())
             .Replace("{{AUDIT_STALE}}", auditStale.ToString())
             .Replace("{{AUDIT_ERRORS}}", auditErrors.ToString())
             .Replace("{{AUDIT_STATUS}}", auditStatus)

--- a/src/dotnet/ReSharperPlugin.Fathom/Handlers/UeProjectHandler.cs
+++ b/src/dotnet/ReSharperPlugin.Fathom/Handlers/UeProjectHandler.cs
@@ -174,13 +174,15 @@ public class UeProjectHandler : IRequestHandler
                              - auditData.StructureCount
                              - auditData.ControlRigCount
                              - auditData.MaterialCount
-                             - auditData.BehaviorTreeCount,
+                             - auditData.BehaviorTreeCount
+                             - auditData.StateTreeCount,
             DataTableCount = auditData.DataTableCount,
             DataAssetCount = auditData.DataAssetCount,
             StructureCount = auditData.StructureCount,
             ControlRigCount = auditData.ControlRigCount,
             MaterialCount = auditData.MaterialCount,
             BehaviorTreeCount = auditData.BehaviorTreeCount,
+            StateTreeCount = auditData.StateTreeCount,
             StaleCount = auditData.StaleCount,
             ErrorCount = auditData.ErrorCount,
         };

--- a/src/dotnet/ReSharperPlugin.Fathom/Mcp/FathomMcpServer.cs
+++ b/src/dotnet/ReSharperPlugin.Fathom/Mcp/FathomMcpServer.cs
@@ -56,15 +56,15 @@ namespace ReSharperPlugin.Fathom.Mcp
                 new ToolParam("file", "string", "Blueprint package path (e.g. /Game/Blueprints/BP_Player)", required: true)),
 
             new ToolDef("get_blueprint_audit",
-                "[UE5] Get cached audit data for Blueprints, DataTables, DataAssets, and Control Rigs. Returns 409 if stale, 503 if not ready.",
+                "[UE5] Get cached audit data for Blueprints, DataTables, DataAssets, Materials, Control Rigs, BehaviorTrees, and StateTrees. Returns 409 if stale, 503 if not ready.",
                 "/blueprint-audit"),
 
             new ToolDef("refresh_blueprint_audit",
-                "[UE5] Trigger background refresh of Blueprint, DataTable, DataAsset, and Control Rig audit data.",
+                "[UE5] Trigger background refresh of all asset audit data (Blueprints, DataTables, DataAssets, Materials, Control Rigs, BehaviorTrees, StateTrees).",
                 "/blueprint-audit/refresh"),
 
             new ToolDef("get_audit_status",
-                "[UE5] Check status of Blueprint/DataTable/DataAsset/ControlRig audit refresh.",
+                "[UE5] Check status of asset audit refresh.",
                 "/blueprint-audit/status"),
 
             // Asset search / detail

--- a/src/dotnet/ReSharperPlugin.Fathom/Models/BlueprintModels.cs
+++ b/src/dotnet/ReSharperPlugin.Fathom/Models/BlueprintModels.cs
@@ -233,6 +233,16 @@ public class BlueprintClassInfo
         public int BehaviorTreeCount { get; set; }
 
         /// <summary>
+        /// List of StateTree audit entries (only populated when fresh).
+        /// </summary>
+        public List<BlueprintAuditEntry> StateTrees { get; set; }
+
+        /// <summary>
+        /// Number of StateTree audit entries.
+        /// </summary>
+        public int StateTreeCount { get; set; }
+
+        /// <summary>
         /// Examples of stale entries (when status is "stale", first 10).
         /// </summary>
         public List<BlueprintAuditEntry> StaleExamples { get; set; }

--- a/src/dotnet/ReSharperPlugin.Fathom/Models/ProjectStatusInfo.cs
+++ b/src/dotnet/ReSharperPlugin.Fathom/Models/ProjectStatusInfo.cs
@@ -22,6 +22,8 @@ public static class AuditCapabilities
             "Materials and Material Instances (properties, parameters, expression graph)"),
         new AuditedAssetType("BehaviorTree",
             "Behavior Trees with blackboard keys, tree structure, decorators, services, and task properties"),
+        new AuditedAssetType("StateTree",
+            "State Trees with state hierarchy, tasks, transitions, property bindings, and evaluators"),
     };
 }
 
@@ -89,6 +91,7 @@ public class AuditInfo
     public int ControlRigCount { get; set; }
     public int MaterialCount { get; set; }
     public int BehaviorTreeCount { get; set; }
+    public int StateTreeCount { get; set; }
     public int StaleCount { get; set; }
     public int ErrorCount { get; set; }
 }

--- a/src/dotnet/ReSharperPlugin.Fathom/Resources/index.html
+++ b/src/dotnet/ReSharperPlugin.Fathom/Resources/index.html
@@ -540,6 +540,7 @@
                 <div class="status-row"><span class="status-row-label">ControlRigs</span><span class="status-row-value">{{AUDIT_CR}}</span></div>
                 <div class="status-row"><span class="status-row-label">Materials</span><span class="status-row-value">{{AUDIT_MAT}}</span></div>
                 <div class="status-row"><span class="status-row-label">BehaviorTrees</span><span class="status-row-value">{{AUDIT_BT}}</span></div>
+                <div class="status-row"><span class="status-row-label">StateTrees</span><span class="status-row-value">{{AUDIT_ST}}</span></div>
                 <div class="status-row" style="margin-top: 8px; border-top: 1px solid var(--border); padding-top: 8px;"><span class="status-row-label">Stale</span><span class="status-row-value">{{AUDIT_STALE}}</span></div>
                 <div class="status-row"><span class="status-row-label">Errors</span><span class="status-row-value">{{AUDIT_ERRORS}}</span></div>
             </div>
@@ -610,7 +611,7 @@
                     <tr>
                         <td><span class="endpoint-method method-get">GET</span></td>
                         <td><span class="endpoint-path">/blueprint-audit</span></td>
-                        <td class="endpoint-desc">Get audit data for Blueprints, DataTables, DataAssets, Structures, ControlRigs, Materials, BehaviorTrees <span class="endpoint-badge">UE5</span></td>
+                        <td class="endpoint-desc">Get audit data for Blueprints, DataTables, DataAssets, Structures, ControlRigs, Materials, BehaviorTrees, StateTrees <span class="endpoint-badge">UE5</span></td>
                     </tr>
                     <tr>
                         <td><span class="endpoint-method method-get">GET</span></td>

--- a/src/dotnet/ReSharperPlugin.Fathom/Services/BlueprintAuditService.cs
+++ b/src/dotnet/ReSharperPlugin.Fathom/Services/BlueprintAuditService.cs
@@ -89,6 +89,7 @@ public class BlueprintAuditService
         var controlRigs = new List<BlueprintAuditEntry>();
         var materials = new List<BlueprintAuditEntry>();
         var behaviorTrees = new List<BlueprintAuditEntry>();
+        var stateTrees = new List<BlueprintAuditEntry>();
         var staleCount = 0;
         var errorCount = 0;
 
@@ -105,6 +106,7 @@ public class BlueprintAuditService
                 case "ControlRig": controlRigs.Add(entry); break;
                 case "Material": materials.Add(entry); break;
                 case "BehaviorTree": behaviorTrees.Add(entry); break;
+                case "StateTree": stateTrees.Add(entry); break;
                 default: blueprints.Add(entry); break;
             }
 
@@ -112,7 +114,7 @@ public class BlueprintAuditService
             if (entry.Error != null) errorCount++;
         }
 
-        var totalCount = blueprints.Count + dataTables.Count + dataAssets.Count + structures.Count + controlRigs.Count + materials.Count + behaviorTrees.Count;
+        var totalCount = blueprints.Count + dataTables.Count + dataAssets.Count + structures.Count + controlRigs.Count + materials.Count + behaviorTrees.Count + stateTrees.Count;
 
         if (totalCount == 0)
         {
@@ -135,7 +137,7 @@ public class BlueprintAuditService
             DateTime? lastRefresh;
             lock (_auditLock) { lastRefresh = _lastAuditRefresh; }
 
-            var allEntries = blueprints.Concat(dataTables).Concat(dataAssets).Concat(structures).Concat(controlRigs).Concat(materials).Concat(behaviorTrees);
+            var allEntries = blueprints.Concat(dataTables).Concat(dataAssets).Concat(structures).Concat(controlRigs).Concat(materials).Concat(behaviorTrees).Concat(stateTrees);
             return new BlueprintAuditResult
             {
                 Status = "stale",
@@ -149,6 +151,7 @@ public class BlueprintAuditService
                 ControlRigCount = controlRigs.Count,
                 MaterialCount = materials.Count,
                 BehaviorTreeCount = behaviorTrees.Count,
+                StateTreeCount = stateTrees.Count,
                 Action = "Call /blueprint-audit/refresh to update audit data",
                 LastRefresh = lastRefresh?.ToString("o"),
                 StaleExamples = allEntries.Where(b => b.IsStale).Take(_config.MaxStaleExamples).ToList(),
@@ -171,6 +174,7 @@ public class BlueprintAuditService
             ControlRigCount = controlRigs.Count,
             MaterialCount = materials.Count,
             BehaviorTreeCount = behaviorTrees.Count,
+            StateTreeCount = stateTrees.Count,
             LastRefresh = refresh?.ToString("o"),
             Blueprints = blueprints,
             DataTables = dataTables,
@@ -179,6 +183,7 @@ public class BlueprintAuditService
             ControlRigs = controlRigs,
             Materials = materials,
             BehaviorTrees = behaviorTrees,
+            StateTrees = stateTrees,
             VersionNote = versionNote
         };
     }
@@ -512,6 +517,7 @@ public class BlueprintAuditService
         if (data.ContainsKey("ClassPath")) return "DataAsset";
         if (data.ContainsKey("Domain") || data.ContainsKey("BlendMode")) return "Material";
         if (data.TryGetValue("BlueprintType", out var t) && t?.ToString() == "BehaviorTree") return "BehaviorTree";
+        if (data.TryGetValue("BlueprintType", out var st) && st?.ToString() == "StateTree") return "StateTree";
         if (data.TryGetValue("BlueprintType", out var bt) && bt?.ToString() == "ControlRig") return "ControlRig";
         if (data.ContainsKey("ParentClass")) return "Blueprint";
         return "Structure";


### PR DESCRIPTION
## Summary

- Adds StateTree recognition and categorization to the Rider plugin
- Companion to Tideshift-Labs/Fathom-UnrealEngine#9 (StateTree auditor in the UE plugin)
- Mechanical additions following the existing BehaviorTree pattern across 6 files

## Changes

- **ProjectStatusInfo.cs**: Add StateTree to `SupportedTypes[]` and `AuditInfo`
- **BlueprintModels.cs**: Add `StateTrees` list + `StateTreeCount` to `BlueprintAuditResult`
- **BlueprintAuditService.cs**: Detect `Type: StateTree` in `InferAssetType()`, add categorization case, include in totals
- **AuditMarkdownFormatter.cs**: Render StateTree section in summary + header counts
- **UeProjectHandler.cs**: Include StateTreeCount in `/ue-project` audit stats
- **FathomMcpServer.cs**: Update MCP tool descriptions to list all supported asset types

## Test plan

- [ ] Build Rider plugin
- [ ] Open a UE project with StateTree audits present
- [ ] Verify `/ue-project` shows StateTreeCount
- [ ] Verify `/blueprint-audit` returns StateTrees in the response
- [ ] Verify MCP tool descriptions include StateTree

Fixes Tideshift-Labs/Fathom#16

🤖 Generated with [Claude Code](https://claude.com/claude-code)